### PR TITLE
Drop Clang3.{4,5}, test Clang3.{6,7}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,6 @@ matrix:
         apt:
           packages: clang-3.6
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
-    - env: CC=clang-3.5 CXX=clang++-3.5
-      addons:
-        apt:
-          packages: clang-3.5
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5']
-    - env: CC=clang-3.4 CXX=clang++-3.4
-      addons:
-        apt:
-          packages: clang-3.4
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.4']
 
 before_install:
   - export PATH="$HOME/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,26 @@ matrix:
         apt:
           packages: clang-3.8
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise']
+    - env: CC=clang-3.7 CXX=clang++-3.7
+      addons:
+        apt:
+          packages: clang-3.7
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
+    - env: CC=clang-3.6 CXX=clang++-3.6
+      addons:
+        apt:
+          packages: clang-3.6
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
+    - env: CC=clang-3.5 CXX=clang++-3.5
+      addons:
+        apt:
+          packages: clang-3.5
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5']
+    - env: CC=clang-3.4 CXX=clang++-3.4
+      addons:
+        apt:
+          packages: clang-3.4
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.4']
 
 before_install:
   - export PATH="$HOME/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 before_install:
   - export PATH="$HOME/bin:$PATH"
   - mkdir -p ~/bin /tmp/tools
-  - wget --no-check-certificate --no-clobber -O /tmp/tools/cmake https://cmake.org/files/v3.4/cmake-3.4.0-rc3-Linux-x86_64.sh || true
+  - wget --no-check-certificate --no-clobber -O /tmp/tools/cmake https://cmake.org/files/v3.4/cmake-3.4.3-rc3-Linux-x86_64.sh || true
   - chmod -R +x /tmp/tools
 
 install: /tmp/tools/cmake --prefix="$HOME" --exclude-subdir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
     apply_compiler_flags()
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4)
-        message(FATAL_ERROR "Clang must be at least version 3.4!")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6)
+        message(FATAL_ERROR "Clang must be at least version 3.6!")
     endif()
 
     apply_compiler_flags()


### PR DESCRIPTION
Clang3.{4,5} were dropped, because they [were failing](https://travis-ci.org/nabijaczleweli/tppi/builds/106056142).
